### PR TITLE
fix .drop with negative amount

### DIFF
--- a/observable.js
+++ b/observable.js
@@ -712,6 +712,7 @@ const [Observable, Subscriber] = (() => {
             // 1. If remaining is > 0, then decrement remaining and abort these steps.
             if (remaining > 0) return (remaining -= 1);
             // 2. Assert: remaining is 0.
+            if (remaining != 0) return;
             // 3. Run subscriber’s next() method with the passed in value.
             subscriber.next(value);
           },


### PR DESCRIPTION
Fix wpt test for `.drop(-1)` - the spec is not clear what should happen if the assertion (=0) is not met.

When passing negative values to drop, the wpt test [assumes the max bigint for remaining](https://github.com/web-platform-tests/wpt/blob/0fc79d8e619d1ab680b2688e8ec6b9dd51b19b26/dom/observable/tentative/observable-drop.any.js#L143-L149).

Instead of introduce dependency to BigInt or hardcode a value, just check if remaining is not 0.

before:
![image](https://github.com/user-attachments/assets/85062489-f905-48f4-873e-350539692743)

with this change:
![image](https://github.com/user-attachments/assets/f6e3dd5d-e000-46a8-8401-e0d22dae8ce4)
