### PR TITLE
fix .every subscribeTo with internalOptions

### DIFF
--- a/observable.js
+++ b/observable.js
@@ -1279,7 +1279,7 @@ const [Observable, Subscriber] = (() => {
             reject(e);
             controller.abort(e);
           }
-          // 2. Increment idx.
+          // 2. Set idx to idx + 1.
           idx += 1;
           // 3. If passed is false, then resolve p with false, and signal abort controller.
           if (!passed) {
@@ -1296,9 +1296,9 @@ const [Observable, Subscriber] = (() => {
           resolve(true);
         },
       });
-      // 5. Subscribe to this given observer and options.
-      subscribeTo(this, observer, options);
-      // 6. Return p.
+      // 8. Subscribe to this given observer and internal options.
+      subscribeTo(this, observer, internalOptions);
+      // 9. Return p.
       return p;
     }
 


### PR DESCRIPTION
fix .every subscribeTo with internalOptions instead of options

reducing failed tests from 32 (main branch) to 30 (this branch)