### PR TITLE
fix multiple from() tested behaviours

### DIFF
--- a/observable.js
+++ b/observable.js
@@ -99,10 +99,10 @@ const [Observable, Subscriber] = (() => {
     return asyncIterator;
   }
 
-  function getIterator(obj, kind = "SYNC") {
+  function getIterator(obj, isAsync) {
     let method = undefined;
     // 1. if kind is ASYNC, then
-    if (kind === "ASYNC") {
+    if (isAsync) {
       // 1.a. Let method be ? GetMethod(obj, %Symbol.asyncIterator%).
       method = obj[Symbol.asyncIterator];
       // 1.b. If method is undefined, then
@@ -529,7 +529,7 @@ const [Observable, Subscriber] = (() => {
           let iteratorRecordCompletion;
           try {
             // 6.2. Let iteratorRecordCompletion be GetIterator(value, async).
-            iteratorRecordCompletion = getIterator(value, "ASYNC");
+            iteratorRecordCompletion = getIterator(value, true);
           } catch (error) {
             // 6.3. If iteratorRecordCompletion is a throw completion, then run subscriber’s error() method with iteratorRecordCompletion’s [[Value]] and abort these steps.
             subscriber.error(error);
@@ -567,7 +567,7 @@ const [Observable, Subscriber] = (() => {
           let iteratorRecordCompletion;
           try {
             // 8.2. Let iteratorRecordCompletion be GetIterator(value, sync).
-            iteratorRecordCompletion = getIterator(value, "SYNC");
+            iteratorRecordCompletion = getIterator(value, false);
           } catch (error) {
             // 8.3. If iteratorRecordCompletion is a throw completion, then run subscriber’s error() method, given iteratorRecordCompletion’s [[Value]], and abort these steps.
             subscriber.error(error);


### PR DESCRIPTION
tests fixed:

- `from(): Asynchronous iterable conversion, with synchronous iterable fallback`
- `from(): Async iterable: error thrown from IteratorRecord#return() is wrapped in rejected Promise`
- `from(): Abort after complete does NOT call IteratorRecord#return()`

tests mysteriously now running (and passing):

- `from(): Aborting an async iterable subscription stops subsequent next() calls, but old next() Promise reactions are web-observable`
- `No error is reported when aborting a subscription to a sync iterator that has no `return()` implementation`
- `map()'s internal observer's next steps do not crash in a detached document`
- `take(): No crash when take(1) unsubscribes from its source when next() is called, and the Subscriber iterates over the rest of the Observables`

before: 
<img width="143" height="143" alt="image" src="https://github.com/user-attachments/assets/f6819b2d-60ad-4b15-99a2-9d05ee9e9b7a" />

after:
<img width="135" height="87" alt="image" src="https://github.com/user-attachments/assets/6cd06820-dfff-450f-9611-956a8b1da3a1" />

