### PR TITLE
Fix error TS1038

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -919,11 +919,11 @@ declare global {
 
   // XMLHttpRequestUpload inherits from XMLHttpRequestEventTarget
 
-  declare function when<K extends keyof WindowEventMap>(
+  function when<K extends keyof WindowEventMap>(
     event: K,
     options?: ObservableEventListenerOptions
   ): Observable<WindowEventMap[K]>;
-  declare function when(
+  function when(
     type: string,
     options?: ObservableEventListenerOptions
   ): Observable<Event>;


### PR DESCRIPTION
`A 'declare' modifier cannot be used in an already ambient context.` 

The inner `declare` modifier is not needed since the entire block is wrapped in `global declare`.

Ref: https://medium.com/@turingvang/ts1038-a-declare-modifier-cannot-be-used-in-an-already-ambient-context-01fdf172781a